### PR TITLE
neoforge 1.21.1 fixed moon crystal crafting recipe

### DIFF
--- a/appNeoForge/1.21.1/src/main/resources/data/fantasy_armor/recipe/moon_crystal.json
+++ b/appNeoForge/1.21.1/src/main/resources/data/fantasy_armor/recipe/moon_crystal.json
@@ -9,5 +9,5 @@
         "#": { "item": "minecraft:glow_ink_sac" },
         "X": { "item": "minecraft:amethyst_shard" }
     },
-    "result": { "item": "fantasy_armor:moon_crystal" }
+    "result": { "id": "fantasy_armor:moon_crystal" }
 }


### PR DESCRIPTION
according to [documentation](https://docs.neoforged.net/docs/1.21.1/resources/server/recipes/builtin) in crafting recipe `results`, item id should not be mentioned as `"item"` but as `"id"`

fixes #28 